### PR TITLE
Move message mock to helpers file to avoid duplication

### DIFF
--- a/test/unit/commands/joke.test.js
+++ b/test/unit/commands/joke.test.js
@@ -2,6 +2,7 @@ const tap = require('tap')
 
 const {
 	each,
+	message,
 	runWith,
 } = require('helpers')
 
@@ -9,12 +10,6 @@ const { factory } = require('commands/joke')
 
 
 // Mocks
-
-const message = (send = () => {}) => ({
-	channel: {
-		send,
-	},
-})
 
 const DEFAULT_JOKE = {
 	id: '123',

--- a/test/unit/commands/persist.test.js
+++ b/test/unit/commands/persist.test.js
@@ -8,15 +8,12 @@ const {
 
 const {
   each,
+  message,
   runWith,
 } = require('helpers')
 
 
 // Mocks
-
-const message = (send = () => {}) => ({
-	channel: { send },
-})
 
 const withStore = ({ save, load, remove }) => ({
 	store: {

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -11,6 +11,10 @@ const makeDescription = (text, args) => {
 	return values.reduce((prev, v) => prev.replace('{}', v), text)
 }
 
+module.exports.message = send => ({
+	channel: { send },
+})
+
 module.exports.runWith = (cmd, {
 	text,
 	message,


### PR DESCRIPTION
The mock `message` which was used both in `joke.test.js` and in `persist.test.js` has been moved to `helpers.js` to avoid duplication.